### PR TITLE
fix: ensure service worker registers reliably in production

### DIFF
--- a/src/components/ServiceWorkerRegistration.tsx
+++ b/src/components/ServiceWorkerRegistration.tsx
@@ -5,16 +5,14 @@ import { useEffect } from 'react';
 export default function ServiceWorkerRegistration() {
   useEffect(() => {
     if ('serviceWorker' in navigator) {
-      window.addEventListener('load', () => {
-        navigator.serviceWorker
-          .register('/sw.js')
-          .then(registration => {
-            console.info('[SW] Service worker registered:', registration.scope);
-          })
-          .catch((error: unknown) => {
-            console.warn('[SW] Service worker registration failed:', error);
-          });
-      });
+      navigator.serviceWorker
+        .register('/sw.js')
+        .then(registration => {
+          console.info('[SW] Service worker registered:', registration.scope);
+        })
+        .catch((error: unknown) => {
+          console.warn('[SW] Service worker registration failed:', error);
+        });
     }
   }, []);
 


### PR DESCRIPTION
Previously, the service worker failed to register in production due to registration being gated behind a window load event, which could fire before the client component mounted in Next.js App Router.

The registration logic is now executed directly in a client-side effect, eliminating timing-related race conditions and ensuring consistent service worker registration across builds.